### PR TITLE
Add additional PHP versions to Laravel 7, 8, and 9 test runners

### DIFF
--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -40,4 +40,4 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit -c phpunit-laravel7.xml.dist

--- a/.github/workflows/run-tests-L9.yml
+++ b/.github/workflows/run-tests-L9.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.4, 8.3, 8.2, 8.1, 8.0, 7.4, 7.3]
         laravel: [9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests-L9.yml
+++ b/.github/workflows/run-tests-L9.yml
@@ -47,4 +47,4 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       - name: Execute tests
-        run: vendor/bin/phpunit -c phpunit-laravel8.xml.dist
+        run: vendor/bin/phpunit -c phpunit-laravel9.xml.dist

--- a/.github/workflows/run-tests-L9.yml
+++ b/.github/workflows/run-tests-L9.yml
@@ -47,4 +47,4 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit -c phpunit-laravel8.xml.dist

--- a/phpunit-laravel7.xml.dist
+++ b/phpunit-laravel7.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php"
+backupGlobals="false"
+colors="true"
+processIsolation="false"
+stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <testsuites>
+        <testsuite name="Eloquent Human Timestamps Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="CACHE_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/phpunit-laravel9.xml.dist
+++ b/phpunit-laravel9.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php"
+backupGlobals="false"
+colors="true"
+processIsolation="false"
+stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <testsuites>
+        <testsuite name="Eloquent Human Timestamps Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="CACHE_DRIVER" value="array"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
Adds newer PHP versions to older test suites to ensure compatibility.