### PR TITLE
Laravel 12

### DIFF
--- a/.github/workflows/run-tests-L10.yml
+++ b/.github/workflows/run-tests-L10.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "ramsey/uuid:^4.0" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L10.yml
+++ b/.github/workflows/run-tests-L10.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L10.yml
+++ b/.github/workflows/run-tests-L10.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L11.yml
+++ b/.github/workflows/run-tests-L11.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "ramsey/uuid:^4.0" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L11.yml
+++ b/.github/workflows/run-tests-L11.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L11.yml
+++ b/.github/workflows/run-tests-L11.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L12.yml
+++ b/.github/workflows/run-tests-L12.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L12.yml
+++ b/.github/workflows/run-tests-L12.yml
@@ -1,4 +1,4 @@
-name: "Run Tests - 8, 9"
+name: "Run Tests - 12"
 
 on: [push, pull_request]
 
@@ -9,31 +9,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.0, 7.4, 7.3]
-        laravel: [9.*, 8.*]
+        php: [8.3,8.4]
+        laravel: [12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.23
-        exclude:
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.3
+          - laravel: 12.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      # - name: Cache dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/.composer/cache/files
-      #     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "ramsey/uuid:^4.0" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L9.yml
+++ b/.github/workflows/run-tests-L9.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/run-tests-L9.yml
+++ b/.github/workflows/run-tests-L9.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
+          composer require "laravel/framework:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" "ramsey/uuid:^4.0" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update --ignore-platform-reqs
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --ignore-platform-reqs
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,15 @@
 
 All notable changes to `eloquent-human-timestamps` will be documented in this file
 
+## 7.0.0 - 2025-11-22
+
+- Laravel 12 support
+- Requires PHP >= 8.3
+
+## 6.0.0 - 2024-03-12
+
+- Laravel 11 support
+
 ## 5.0.0 - 2023-03-13
 
 - Laravel 10 support

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This package provides a trait you can add to an Eloquent model that will automat
 ![Laravel 9 Tests](https://github.com/chrisdicarlo/eloquent-human-timestamps/actions/workflows/run-tests-L9.yml/badge.svg)
 ![Laravel 10 Tests](https://github.com/chrisdicarlo/eloquent-human-timestamps/actions/workflows/run-tests-L10.yml/badge.svg)
 ![Laravel 11 Tests](https://github.com/chrisdicarlo/eloquent-human-timestamps/actions/workflows/run-tests-L11.yml/badge.svg)
+![Laravel 12 Tests](https://github.com/chrisdicarlo/eloquent-human-timestamps/actions/workflows/run-tests-L12.yml/badge.svg)
 [![Total Downloads](https://img.shields.io/packagist/dt/chrisdicarlo/eloquent-human-timestamps.svg?style=flat-square)](https://packagist.org/packages/chrisdicarlo/eloquent-human-timestamps)
 
 ## Version Compatibility
@@ -19,6 +20,7 @@ This package provides a trait you can add to an Eloquent model that will automat
 | 9 | 8.1, 8.0 | 4 |
 | 10 | 8.1, 8.2, 8.3, 8.4 | 5 |
 | 11 | 8.2, 8.3, 8.4 | 6 |
+| 12 | 8.3, 8.4 | 7 |
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2|^8.3|^8.4",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10|^11"
+        "php": "^8.3|^8.4",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10|^11|^12"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0",


### PR DESCRIPTION
This pull request adds support for Laravel 12 and updates the minimum PHP requirement to version 8.3. The changes ensure compatibility with the latest Laravel release and update the test workflows and documentation accordingly.

Laravel 12 and PHP 8.3+ support:

* Updated `composer.json` to require PHP `^8.3|^8.4` and added support for `illuminate/support` version `^12`.
* Added a new GitHub Actions workflow file `run-tests-L12.yml` for testing against Laravel 12 and PHP 8.3/8.4.
* Updated the test matrix in existing workflow files (`run-tests-L7.yml`, `run-tests-L9.yml`, `run-tests-L10.yml`, `run-tests-L11.yml`) to ignore platform requirements during dependency installation, improving CI reliability for all supported Laravel versions. [[1]](diffhunk://#diff-19a217ff14300a9e306f63115e2a50944e50d32ec4faa131d3c4863333b2f468L40-R41) [[2]](diffhunk://#diff-3e06ff23a4c9c444f68bbab1e4bf24204ada582edf72c5881c994068ffb0d030L47-R48) [[3]](diffhunk://#diff-12094a6fd6201b1b2b5979ecf025df616f09dd31ecab11af19807b4179949965L40-R41) [[4]](diffhunk://#diff-898d43ae14296ee4368121230239e8c84a8407936e187bd98e7182274b6ba8f9L40-R41)

Documentation updates:

* Updated `README.md` to include Laravel 12 in the badges and compatibility table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23)
* Added a new entry to the `CHANGELOG.MD` documenting Laravel 12 support and the new PHP requirement.